### PR TITLE
Fixing bug -Element unlocked in panel before being crafted

### DIFF
--- a/Assets/Prefabs/GatheringMode/Zone1Unit.prefab
+++ b/Assets/Prefabs/GatheringMode/Zone1Unit.prefab
@@ -81,7 +81,7 @@ Transform:
   m_GameObject: {fileID: 195350}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -1.22289538, y: 19.9946804, z: 0}
-  m_LocalScale: {x: .787759006, y: .787759006, z: .787759006}
+  m_LocalScale: {x: .787423313, y: .787423313, z: .787423313}
   m_Children:
   - {fileID: 497038}
   - {fileID: 486918}

--- a/Assets/Prefabs/GatheringMode/Zone2Unit.prefab
+++ b/Assets/Prefabs/GatheringMode/Zone2Unit.prefab
@@ -105,7 +105,7 @@ Transform:
   m_GameObject: {fileID: 178324}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 1.27735233, y: 15.7375021, z: 0}
-  m_LocalScale: {x: .787759006, y: .787759006, z: .787759006}
+  m_LocalScale: {x: .787423313, y: .787423313, z: .787423313}
   m_Children:
   - {fileID: 430422}
   - {fileID: 420088}

--- a/Assets/Prefabs/GatheringMode/Zone3Unit.prefab
+++ b/Assets/Prefabs/GatheringMode/Zone3Unit.prefab
@@ -93,7 +93,7 @@ Transform:
   m_GameObject: {fileID: 194838}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -12.9499998, y: 6.03999996, z: 0}
-  m_LocalScale: {x: .787759006, y: .787759006, z: .787759006}
+  m_LocalScale: {x: .787423313, y: .787423313, z: .787423313}
   m_Children:
   - {fileID: 488112}
   - {fileID: 404282}

--- a/Assets/Prefabs/GatheringMode/Zone4Unit.prefab
+++ b/Assets/Prefabs/GatheringMode/Zone4Unit.prefab
@@ -93,7 +93,7 @@ Transform:
   m_GameObject: {fileID: 103640}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: .466461182, y: 12.561512, z: 0}
-  m_LocalScale: {x: .787759006, y: .787759006, z: .787759006}
+  m_LocalScale: {x: .787423313, y: .787423313, z: .787423313}
   m_Children:
   - {fileID: 492262}
   - {fileID: 498286}

--- a/Assets/Scripts/Core/GlobalVars.cs
+++ b/Assets/Scripts/Core/GlobalVars.cs
@@ -115,7 +115,7 @@ public class GlobalVars {
 	public const string UPGRADE_POWERUP_BUTTON_NAME = "UpgradePowerUp";
 	public const string GATHERING_BUTTON_NAME = "Gathering";
     //Release build boolean - SET TO TRUE FOR RELEASE BUILD
-    public static bool RELEASE_BUILD = true;
+    public static bool RELEASE_BUILD = false;
     #endregion
 
     #region ELEMENTS

--- a/Assets/Scripts/CraftingMode/Controllers/CraftingControl.cs
+++ b/Assets/Scripts/CraftingMode/Controllers/CraftingControl.cs
@@ -83,7 +83,8 @@ public class CraftingControl : MonoBehaviour {
 	public Text inventoryNumber;
 	public Button craftButton;
 
-	//element info 
+    //element info 
+    Element result;
 	private string resultElement, parentElement1, parentElement2;
 	private int resultTier;
 	private bool isNew;
@@ -149,6 +150,7 @@ public class CraftingControl : MonoBehaviour {
 			if (OnElementCreated != null && validInventoryAmounts()) {
 				Utility.Log("created an element and fired the event");
 				OnElementCreated(resultElement, parentElement1, parentElement2, isNew);
+                UnlockElement();
 			}
 
 			//lowers the flag to craft if the player has run out of either element
@@ -293,28 +295,32 @@ public class CraftingControl : MonoBehaviour {
 		subMessage.color = regularColor;
 		elementName.color = regularColor;
 	}
-
-	//sets up the combination for a new element
-	public void combine () {
-		//element gameobject
-
+    //method to be called from capture script to unlock the element ONCE it has been clicked on to be crafted
+    public void UnlockElement()
+    {
+        result = GlobalVars.RECIPES_BY_NAME[parentElement1 + parentElement2];
+        //result.unlock();
+        //calls the event
+        if (OnElementDiscovered != null)
+        {
+            OnElementDiscovered(result.getName());
+        }       
+    }
+    //sets up the combination for a new element
+    public void combine () {
+        //element gameobject
 		if (GlobalVars.RECIPES_BY_NAME.ContainsKey(parentElement1+parentElement2)) {//checks if the elements combine to form a third
 			containsBaseElement = false;
 
 			//gets the new element
-			Element result = GlobalVars.RECIPES_BY_NAME[parentElement1+parentElement2];
+			result = GlobalVars.RECIPES_BY_NAME[parentElement1+parentElement2];
 
 			//updates the record of the elements
 			if (!result.isElementUnlocked()) {
-				result.unlock();
-				GlobalVars.NUMBER_ELEMENTS_UNLOCKED++;
+                result.unlock();
+                GlobalVars.NUMBER_ELEMENTS_UNLOCKED++;
 				panelControl.updatePercentUnlocked();
 				isNew = true;
-
-				//calls the event
-				if (OnElementDiscovered != null) {
-					OnElementDiscovered(result.getName());
-				}
 
 				//checks if the whole tier of elements is unlocked and sends the event
 				if (OnTierCompleted != null) {
@@ -331,7 +337,7 @@ public class CraftingControl : MonoBehaviour {
 				isNew = false;
 			}
 			PlayerPrefs.SetInt(result.getName()+GlobalVars.UNLOCK_STRING, 1); 
-
+            
 			//makes the new element
 			myElementGameObject.name = result.getName();
 			resultElement = myElementGameObject.name;


### PR DESCRIPTION
When the player dragged both elements into the crafting zones the new element that would be made was being displayed in the panel below as unlocked before the player had clicked on the new element to craft it.
